### PR TITLE
Add interactive curate TUI for manual post tagging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +307,20 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -396,6 +425,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +475,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1107,6 +1195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1232,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1274,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1245,6 +1370,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -1269,6 +1400,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1314,6 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1326,9 +1467,11 @@ dependencies = [
  "assert_cmd",
  "clap",
  "config",
+ "crossterm",
  "news-tagger-adapters",
  "news-tagger-domain",
  "predicates",
+ "ratatui",
  "secrecy",
  "serde",
  "serde_json",
@@ -1521,6 +1664,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -1818,6 +1967,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2146,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1983,7 +2166,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2164,6 +2347,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2424,6 +2628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2649,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2486,7 +2718,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2865,6 +3097,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3315,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ bech32 = "0.11"
 # Secrets
 secrecy = { version = "0.10", features = ["serde"] }
 
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"
+
 # UUID
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ anyhow.workspace = true
 secrecy.workspace = true
 sha2.workspace = true
 time.workspace = true
+ratatui.workspace = true
+crossterm.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -39,6 +39,9 @@ pub enum Commands {
 
     /// Validate configuration and show status
     Doctor(DoctorArgs),
+
+    /// Interactive TUI for curating post classifications
+    Curate(CurateArgs),
 }
 
 #[derive(Args, Debug)]
@@ -154,4 +157,19 @@ pub struct DoctorArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct CurateArgs {
+    /// Input JSONL file with collected posts
+    #[arg(long, default_value = "./collected.jsonl")]
+    pub input: PathBuf,
+
+    /// Output JSONL file for curated classifications
+    #[arg(long, default_value = "./curated.jsonl")]
+    pub output: PathBuf,
+
+    /// Override definitions directory
+    #[arg(long)]
+    pub definitions_dir: Option<PathBuf>,
 }

--- a/crates/cli/src/commands/curate.rs
+++ b/crates/cli/src/commands/curate.rs
@@ -1,0 +1,692 @@
+//! Curate command - interactive TUI for manual post tagging
+
+use anyhow::{Context, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use news_tagger_adapters::definitions::FilesystemDefinitionsRepo;
+use news_tagger_domain::{DefinitionsRepo, SourcePost, TagDefinition};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+
+use crate::args::CurateArgs;
+use crate::config::AppConfig;
+
+#[derive(Serialize, Deserialize)]
+struct CuratedPost {
+    post_id: String,
+    author: String,
+    text: String,
+    url: String,
+    tags: Vec<String>,
+}
+
+enum Mode {
+    Normal,
+    NewTag,
+}
+
+enum InputField {
+    Id,
+    Title,
+    Short,
+    Description,
+}
+
+struct NewTagDraft {
+    id: String,
+    title: String,
+    short: String,
+    description: String,
+}
+
+impl NewTagDraft {
+    fn new() -> Self {
+        Self {
+            id: String::new(),
+            title: String::new(),
+            short: String::new(),
+            description: String::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.id.clear();
+        self.title.clear();
+        self.short.clear();
+        self.description.clear();
+    }
+}
+
+struct App {
+    posts: Vec<SourcePost>,
+    definitions: Vec<TagDefinition>,
+    current_post: usize,
+    selected_tag: usize,
+    tag_selections: HashSet<String>,
+    curated_ids: HashSet<String>,
+    mode: Mode,
+    input_field: InputField,
+    new_tag: NewTagDraft,
+    output_path: PathBuf,
+    definitions_dir: PathBuf,
+    message: Option<String>,
+    should_quit: bool,
+    tag_scroll_offset: usize,
+}
+
+impl App {
+    fn new(
+        posts: Vec<SourcePost>,
+        definitions: Vec<TagDefinition>,
+        curated_ids: HashSet<String>,
+        output_path: PathBuf,
+        definitions_dir: PathBuf,
+    ) -> Self {
+        let current_post = posts
+            .iter()
+            .position(|p| !curated_ids.contains(&p.id))
+            .unwrap_or(0);
+
+        Self {
+            posts,
+            definitions,
+            current_post,
+            selected_tag: 0,
+            tag_selections: HashSet::new(),
+            curated_ids,
+            mode: Mode::Normal,
+            input_field: InputField::Id,
+            new_tag: NewTagDraft::new(),
+            output_path,
+            definitions_dir,
+            message: None,
+            should_quit: false,
+            tag_scroll_offset: 0,
+        }
+    }
+
+    fn current_post(&self) -> Option<&SourcePost> {
+        self.posts.get(self.current_post)
+    }
+
+    fn remaining(&self) -> usize {
+        self.posts
+            .iter()
+            .skip(self.current_post)
+            .filter(|p| !self.curated_ids.contains(&p.id))
+            .count()
+    }
+
+    fn save_current(&mut self) -> Result<()> {
+        if let Some(post) = self.posts.get(self.current_post) {
+            let mut tags: Vec<String> = self.tag_selections.iter().cloned().collect();
+            tags.sort();
+            let curated = CuratedPost {
+                post_id: post.id.clone(),
+                author: post.author.clone(),
+                text: post.text.clone(),
+                url: post.url.clone(),
+                tags,
+            };
+            let line = serde_json::to_string(&curated)?;
+            use std::io::Write;
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.output_path)?;
+            writeln!(file, "{}", line)?;
+            self.curated_ids.insert(post.id.clone());
+            let tag_count = self.tag_selections.len();
+            self.message = Some(format!("Saved with {} tag(s)", tag_count));
+        }
+        self.tag_selections.clear();
+        self.advance_to_next();
+        Ok(())
+    }
+
+    fn skip_current(&mut self) {
+        self.message = Some("Skipped".to_string());
+        self.tag_selections.clear();
+        self.advance_to_next();
+    }
+
+    fn advance_to_next(&mut self) {
+        for i in (self.current_post + 1)..self.posts.len() {
+            if !self.curated_ids.contains(&self.posts[i].id) {
+                self.current_post = i;
+                self.selected_tag = 0;
+                self.tag_scroll_offset = 0;
+                return;
+            }
+        }
+        self.should_quit = true;
+        self.message = Some("All posts curated!".to_string());
+    }
+
+    fn go_prev(&mut self) {
+        if self.current_post > 0 {
+            for i in (0..self.current_post).rev() {
+                if !self.curated_ids.contains(&self.posts[i].id) {
+                    self.current_post = i;
+                    self.tag_selections.clear();
+                    self.selected_tag = 0;
+                    self.tag_scroll_offset = 0;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn toggle_tag(&mut self) {
+        if let Some(def) = self.definitions.get(self.selected_tag) {
+            let id = def.id.clone();
+            if self.tag_selections.contains(&id) {
+                self.tag_selections.remove(&id);
+            } else {
+                self.tag_selections.insert(id);
+            }
+        }
+    }
+
+    fn create_tag(&mut self) -> Result<()> {
+        let id = self.new_tag.id.trim().to_string();
+        let title_input = self.new_tag.title.trim().to_string();
+        let short = self.new_tag.short.trim().to_string();
+        let description = self.new_tag.description.trim().to_string();
+
+        if id.is_empty() {
+            self.message = Some("Tag ID cannot be empty".to_string());
+            return Ok(());
+        }
+
+        if !id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            self.message = Some("ID must be lowercase letters, digits, underscores".to_string());
+            return Ok(());
+        }
+
+        if self.definitions.iter().any(|d| d.id == id) {
+            self.message = Some(format!("Tag '{}' already exists", id));
+            return Ok(());
+        }
+
+        let title = if title_input.is_empty() {
+            id.replace('_', " ")
+                .split_whitespace()
+                .map(|w| {
+                    let mut c = w.chars();
+                    match c.next() {
+                        None => String::new(),
+                        Some(f) => f.to_uppercase().to_string() + c.as_str(),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        } else {
+            title_input
+        };
+
+        let desc = if description.is_empty() {
+            format!("Posts about {}.", title.to_lowercase())
+        } else {
+            description
+        };
+
+        let file_path = self.definitions_dir.join(format!("{}.md", id));
+        let mut content = format!("---\nid: {}\ntitle: {}\n", id, title);
+        if !short.is_empty() {
+            content.push_str(&format!("short: \"{}\"\n", short));
+        }
+        content.push_str("---\n\n");
+        content.push_str(&format!("# {}\n\n{}\n", title, desc));
+
+        std::fs::write(&file_path, &content)?;
+
+        let def = TagDefinition {
+            id: id.clone(),
+            title: title.clone(),
+            aliases: vec![],
+            short: if short.is_empty() { None } else { Some(short) },
+            content,
+            file_path: file_path.display().to_string(),
+        };
+        self.definitions.push(def);
+        self.definitions.sort_by(|a, b| a.id.cmp(&b.id));
+
+        self.tag_selections.insert(id.clone());
+
+        self.message = Some(format!("Created tag '{}'", id));
+        self.new_tag.clear();
+        self.mode = Mode::Normal;
+        Ok(())
+    }
+
+    fn handle_normal_key(&mut self, key: KeyCode) -> Result<bool> {
+        match key {
+            KeyCode::Char('q') => return Ok(true),
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.selected_tag + 1 < self.definitions.len() {
+                    self.selected_tag += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.selected_tag > 0 {
+                    self.selected_tag -= 1;
+                }
+            }
+            KeyCode::Char(' ') => self.toggle_tag(),
+            KeyCode::Enter => self.save_current()?,
+            KeyCode::Char('s') => self.skip_current(),
+            KeyCode::Char('n') => {
+                self.mode = Mode::NewTag;
+                self.input_field = InputField::Id;
+                self.new_tag.clear();
+            }
+            KeyCode::Char('p') => self.go_prev(),
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn handle_new_tag_key(&mut self, key: KeyCode) -> Result<bool> {
+        match key {
+            KeyCode::Esc => {
+                self.mode = Mode::Normal;
+                self.new_tag.clear();
+            }
+            KeyCode::Tab => {
+                self.input_field = match self.input_field {
+                    InputField::Id => InputField::Title,
+                    InputField::Title => InputField::Short,
+                    InputField::Short => InputField::Description,
+                    InputField::Description => InputField::Id,
+                };
+            }
+            KeyCode::BackTab => {
+                self.input_field = match self.input_field {
+                    InputField::Id => InputField::Description,
+                    InputField::Title => InputField::Id,
+                    InputField::Short => InputField::Title,
+                    InputField::Description => InputField::Short,
+                };
+            }
+            KeyCode::Enter => {
+                self.create_tag()?;
+            }
+            KeyCode::Backspace => {
+                self.current_input_mut().pop();
+            }
+            KeyCode::Char(c) => {
+                self.current_input_mut().push(c);
+            }
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn current_input_mut(&mut self) -> &mut String {
+        match self.input_field {
+            InputField::Id => &mut self.new_tag.id,
+            InputField::Title => &mut self.new_tag.title,
+            InputField::Short => &mut self.new_tag.short,
+            InputField::Description => &mut self.new_tag.description,
+        }
+    }
+}
+
+fn ui(f: &mut ratatui::Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(6),
+            Constraint::Min(8),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    // Post panel
+    if let Some(post) = app.current_post() {
+        let remaining = app.remaining();
+        let total = app.posts.len();
+        let curated = app.curated_ids.len();
+        let post_block = Block::default()
+            .title(format!(
+                " Post {}/{} | {} curated | {} remaining | @{} ",
+                app.current_post + 1,
+                total,
+                curated,
+                remaining,
+                post.author
+            ))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+
+        let text = Text::from(vec![
+            Line::from(Span::styled(&post.text, Style::default().fg(Color::White))),
+            Line::from(""),
+            Line::from(Span::styled(&post.url, Style::default().fg(Color::Blue))),
+        ]);
+
+        let paragraph = Paragraph::new(text)
+            .block(post_block)
+            .wrap(Wrap { trim: false });
+
+        f.render_widget(paragraph, chunks[0]);
+    } else {
+        let block = Block::default().title(" No posts ").borders(Borders::ALL);
+        f.render_widget(block, chunks[0]);
+    }
+
+    // Tags panel or new tag form
+    match app.mode {
+        Mode::Normal => render_tags(f, app, chunks[1]),
+        Mode::NewTag => render_new_tag_form(f, app, chunks[1]),
+    }
+
+    // Status bar
+    let status_text = if let Some(ref msg) = app.message {
+        msg.clone()
+    } else {
+        match app.mode {
+            Mode::Normal => {
+                "↑↓/jk: navigate  Space: toggle  Enter: save  s: skip  n: new tag  p: prev  q: quit"
+                    .to_string()
+            }
+            Mode::NewTag => "Tab: next field  Enter: create  Esc: cancel".to_string(),
+        }
+    };
+
+    let status_style = if app.message.is_some() {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let status = Paragraph::new(Line::from(Span::styled(status_text, status_style))).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::DarkGray)),
+    );
+    f.render_widget(status, chunks[2]);
+}
+
+fn render_tags(f: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let tag_items: Vec<ListItem> = app
+        .definitions
+        .iter()
+        .enumerate()
+        .map(|(i, def)| {
+            let selected = app.tag_selections.contains(&def.id);
+            let checkbox = if selected { "[x]" } else { "[ ]" };
+            let cursor = if i == app.selected_tag { ">" } else { " " };
+            let short = def.short.as_deref().unwrap_or("");
+            let text = format!("{} {} {} - {}", cursor, checkbox, def.id, short);
+            let style = if i == app.selected_tag {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else if selected {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(Span::styled(text, style)))
+        })
+        .collect();
+
+    let selected_tags: Vec<&str> = app.tag_selections.iter().map(|s| s.as_str()).collect();
+    let title = if selected_tags.is_empty() {
+        " Tags (Space: toggle, n: new tag) ".to_string()
+    } else {
+        format!(
+            " Tags [{}] (Space: toggle, n: new tag) ",
+            selected_tags.join(", ")
+        )
+    };
+
+    let tag_block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let list = List::new(tag_items).block(tag_block);
+    f.render_widget(list, area);
+}
+
+fn render_new_tag_form(f: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let active_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let inactive_style = Style::default().fg(Color::Gray);
+    let cursor = Span::styled("_", Style::default().fg(Color::Yellow));
+    let no_cursor = Span::raw("");
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled(
+                "  ID:    ",
+                if matches!(app.input_field, InputField::Id) {
+                    active_style
+                } else {
+                    inactive_style
+                },
+            ),
+            Span::styled(&app.new_tag.id, Style::default().fg(Color::White)),
+            if matches!(app.input_field, InputField::Id) {
+                cursor.clone()
+            } else {
+                no_cursor.clone()
+            },
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Title: ",
+                if matches!(app.input_field, InputField::Title) {
+                    active_style
+                } else {
+                    inactive_style
+                },
+            ),
+            Span::styled(&app.new_tag.title, Style::default().fg(Color::White)),
+            if matches!(app.input_field, InputField::Title) {
+                cursor.clone()
+            } else {
+                no_cursor.clone()
+            },
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Short: ",
+                if matches!(app.input_field, InputField::Short) {
+                    active_style
+                } else {
+                    inactive_style
+                },
+            ),
+            Span::styled(&app.new_tag.short, Style::default().fg(Color::White)),
+            if matches!(app.input_field, InputField::Short) {
+                cursor.clone()
+            } else {
+                no_cursor.clone()
+            },
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Desc:  ",
+                if matches!(app.input_field, InputField::Description) {
+                    active_style
+                } else {
+                    inactive_style
+                },
+            ),
+            Span::styled(&app.new_tag.description, Style::default().fg(Color::White)),
+            if matches!(app.input_field, InputField::Description) {
+                cursor.clone()
+            } else {
+                no_cursor.clone()
+            },
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Tab: next field  Enter: create  Esc: cancel",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let form = Paragraph::new(Text::from(lines)).block(
+        Block::default()
+            .title(" New Tag ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Magenta)),
+    );
+    f.render_widget(form, area);
+}
+
+pub async fn execute(args: CurateArgs, config_path: Option<PathBuf>) -> Result<()> {
+    let config = AppConfig::load(config_path.as_deref())?;
+
+    let definitions_dir = args
+        .definitions_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(&config.general.definitions_dir));
+
+    let repo = FilesystemDefinitionsRepo::new(&definitions_dir)
+        .context("Failed to initialize definitions repository")?;
+    let definitions = repo.load().await?;
+
+    let posts = load_posts(&args.input)?;
+    if posts.is_empty() {
+        println!("No posts found in {}", args.input.display());
+        return Ok(());
+    }
+
+    let curated_ids = load_curated_ids(&args.output);
+
+    let uncurated = posts
+        .iter()
+        .filter(|p| !curated_ids.contains(&p.id))
+        .count();
+    if uncurated == 0 {
+        println!("All {} posts already curated!", posts.len());
+        return Ok(());
+    }
+
+    println!(
+        "Loaded {} posts ({} already curated, {} remaining)",
+        posts.len(),
+        curated_ids.len(),
+        uncurated
+    );
+
+    // Set up terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(
+        posts,
+        definitions,
+        curated_ids,
+        args.output.clone(),
+        definitions_dir,
+    );
+
+    // Main event loop
+    let result = run_event_loop(&mut terminal, &mut app);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+
+    result?;
+
+    println!(
+        "Curated {} posts. Output: {}",
+        app.curated_ids.len(),
+        args.output.display()
+    );
+
+    Ok(())
+}
+
+fn run_event_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> Result<()> {
+    loop {
+        terminal.draw(|f| ui(f, app))?;
+
+        if app.should_quit {
+            break;
+        }
+
+        if let Event::Key(key) = event::read()? {
+            app.message = None;
+
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                break;
+            }
+
+            let quit = match app.mode {
+                Mode::Normal => app.handle_normal_key(key.code)?,
+                Mode::NewTag => app.handle_new_tag_key(key.code)?,
+            };
+
+            if quit {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn load_posts(path: &PathBuf) -> Result<Vec<SourcePost>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let mut posts = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(post) = serde_json::from_str::<SourcePost>(line) {
+            posts.push(post);
+        }
+    }
+    Ok(posts)
+}
+
+fn load_curated_ids(path: &PathBuf) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return ids,
+    };
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(curated) = serde_json::from_str::<CuratedPost>(line) {
+            ids.insert(curated.post_id);
+        }
+    }
+    ids
+}

--- a/crates/cli/src/commands/curate.rs
+++ b/crates/cli/src/commands/curate.rs
@@ -349,7 +349,7 @@ impl App {
     }
 }
 
-fn ui(f: &mut ratatui::Frame, app: &App) {
+fn ui(f: &mut ratatui::Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -394,7 +394,7 @@ fn ui(f: &mut ratatui::Frame, app: &App) {
 
     // Tags panel or new tag form
     match app.mode {
-        Mode::Normal => render_tags(f, app, chunks[1]),
+        Mode::Normal => render_tags(f, &mut *app, chunks[1]),
         Mode::NewTag => render_new_tag_form(f, app, chunks[1]),
     }
 
@@ -425,11 +425,23 @@ fn ui(f: &mut ratatui::Frame, app: &App) {
     f.render_widget(status, chunks[2]);
 }
 
-fn render_tags(f: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+fn render_tags(f: &mut ratatui::Frame, app: &mut App, area: ratatui::layout::Rect) {
+    // Adjust scroll offset to keep selected tag visible
+    let inner_height = area.height.saturating_sub(2) as usize; // -2 for borders
+    if inner_height > 0 {
+        if app.selected_tag < app.tag_scroll_offset {
+            app.tag_scroll_offset = app.selected_tag;
+        } else if app.selected_tag >= app.tag_scroll_offset + inner_height {
+            app.tag_scroll_offset = app.selected_tag - inner_height + 1;
+        }
+    }
+
     let tag_items: Vec<ListItem> = app
         .definitions
         .iter()
         .enumerate()
+        .skip(app.tag_scroll_offset)
+        .take(inner_height)
         .map(|(i, def)| {
             let selected = app.tag_selections.contains(&def.id);
             let checkbox = if selected { "[x]" } else { "[ ]" };
@@ -450,12 +462,23 @@ fn render_tags(f: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
         .collect();
 
     let selected_tags: Vec<&str> = app.tag_selections.iter().map(|s| s.as_str()).collect();
+    let scroll_indicator = if app.definitions.len() > inner_height && inner_height > 0 {
+        format!(
+            " [{}-{}/{}]",
+            app.tag_scroll_offset + 1,
+            (app.tag_scroll_offset + inner_height).min(app.definitions.len()),
+            app.definitions.len()
+        )
+    } else {
+        String::new()
+    };
     let title = if selected_tags.is_empty() {
-        " Tags (Space: toggle, n: new tag) ".to_string()
+        format!(" Tags{} (Space: toggle, n: new tag) ", scroll_indicator)
     } else {
         format!(
-            " Tags [{}] (Space: toggle, n: new tag) ",
-            selected_tags.join(", ")
+            " Tags [{}]{} (Space: toggle, n: new tag) ",
+            selected_tags.join(", "),
+            scroll_indicator
         )
     };
 
@@ -593,29 +616,13 @@ pub async fn execute(args: CurateArgs, config_path: Option<PathBuf>) -> Result<(
         uncurated
     );
 
-    // Set up terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
-    let mut app = App::new(
+    let app = run_tui_session(
         posts,
         definitions,
         curated_ids,
         args.output.clone(),
         definitions_dir,
-    );
-
-    // Main event loop
-    let result = run_event_loop(&mut terminal, &mut app);
-
-    // Restore terminal
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-
-    result?;
+    )?;
 
     println!(
         "Curated {} posts. Output: {}",
@@ -626,12 +633,51 @@ pub async fn execute(args: CurateArgs, config_path: Option<PathBuf>) -> Result<(
     Ok(())
 }
 
+/// Guard that restores terminal state on drop, ensuring cleanup
+/// even if setup or the event loop fails partway through.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+fn run_tui_session(
+    posts: Vec<SourcePost>,
+    definitions: Vec<TagDefinition>,
+    curated_ids: HashSet<String>,
+    output_path: PathBuf,
+    definitions_dir: PathBuf,
+) -> Result<App> {
+    enable_raw_mode()?;
+    let _guard = TerminalGuard;
+
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(
+        posts,
+        definitions,
+        curated_ids,
+        output_path,
+        definitions_dir,
+    );
+    run_event_loop(&mut terminal, &mut app)?;
+
+    // _guard drops here, restoring terminal state
+    Ok(app)
+}
+
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
 ) -> Result<()> {
     loop {
-        terminal.draw(|f| ui(f, app))?;
+        terminal.draw(|f| ui(f, &mut *app))?;
 
         if app.should_quit {
             break;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod classify;
 pub mod config;
+pub mod curate;
 pub mod definitions;
 pub mod doctor;
 pub mod fetch;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
         Commands::Definitions(args) => commands::definitions::execute(args, cli.config).await,
         Commands::Config(args) => commands::config::execute(args).await,
         Commands::Doctor(args) => commands::doctor::execute(args, cli.config).await,
+        Commands::Curate(args) => commands::curate::execute(args, cli.config).await,
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `curate` command with a ratatui-based TUI for reviewing collected posts and assigning tag classifications manually
- Supports creating new tag definitions inline (writes `.md` files to definitions dir)
- Saves curated results as JSONL with resume support (skips already-curated posts)

## Usage
```
news-tagger curate --input ./collected.jsonl --output ./curated.jsonl
```

**Key bindings:** ↑↓/jk navigate, Space toggle tag, Enter save, s skip, n new tag, p previous, q quit

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass
- [ ] Run `curate` against collected posts and verify tag toggling works
- [ ] Create a new tag inline and verify the `.md` file is written correctly
- [ ] Quit and restart to verify resume (skips already-curated posts)