### PR TITLE
ci: remove Magic Nix Cache from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
-
       - name: Rust fmt
         run: nix develop -c cargo fmt --all -- --check
 


### PR DESCRIPTION
Removes the `DeterminateSystems/magic-nix-cache-action` step — it has been unreliable in CI (rate-limited local substituter). Nix now fetches from `cache.nixos.org` directly; the Nix installer and Cargo registry cache are unchanged.